### PR TITLE
change array copy method

### DIFF
--- a/src/immot.ts
+++ b/src/immot.ts
@@ -8,7 +8,7 @@ const isArray = Array.isArray;
 
 function shadowAssign<S, KS extends KeyName<S>>(state: S, keyPath: KS, value: Resolve1<S, KS>) {
   if (isArray(state)) {
-    const result = [...state] as unknown as S;
+    const result = state.slice(0) as unknown as S;
     result[keyPath as number] = value;
     return result;
   }


### PR DESCRIPTION
v8 引擎用 .slice(0) 拷贝是最快的
火狐是直接用循环语句最快
ios15 safari 用 .slice() 最快
小米10自带浏览器用 .slice() 最快
以上数据仅供参考
测试地址 https://jsbench.me/9ekycevs70